### PR TITLE
Constructor now takes JSonSerializer

### DIFF
--- a/src/Nancy.Serialization.JsonNet/JsonNetBodyDeserializer.cs
+++ b/src/Nancy.Serialization.JsonNet/JsonNetBodyDeserializer.cs
@@ -1,7 +1,6 @@
 ﻿namespace Nancy.Serialization.JsonNet
 {
     using System;
-    using System.Collections.Generic;
     using System.IO;
     using System.Linq;
     using System.Reflection;
@@ -10,25 +9,23 @@
 
     public class JsonNetBodyDeserializer : IBodyDeserializer
     {
-        private readonly JsonSerializer serializer = new JsonSerializer();
-        
+        private readonly JsonSerializer serializer;
+
         /// <summary>
         /// Empty constructor if no converters are needed
         /// </summary>
         public JsonNetBodyDeserializer()
         {
+            this.serializer = new JsonSerializer();
         }
 
         /// <summary>
-        /// Constructor to use when json converters are needed.
+        /// Constructor to use when a custom serializer are needed.
         /// </summary>
-        /// <param name="converters">Json converters used when deserializing.</param>
-        public JsonNetBodyDeserializer(IEnumerable<JsonConverter> converters)
+        /// <param name="serializer">Json serializer used when deserializing.</param>
+        public JsonNetBodyDeserializer(JsonSerializer serializer)
         {
-            foreach (var converter in converters)
-            {
-                this.serializer.Converters.Add(converter);
-            }
+            this.serializer = serializer;
         }
 
         /// <summary>

--- a/src/Nancy.Serialization.JsonNet/JsonNetSerializer.cs
+++ b/src/Nancy.Serialization.JsonNet/JsonNetSerializer.cs
@@ -7,26 +7,24 @@
 
     public class JsonNetSerializer : ISerializer
     {
-        private readonly JsonSerializer serializer = new JsonSerializer();
-        
+        private readonly JsonSerializer serializer;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="JsonNetSerializer"/> class.
         /// </summary>
         public JsonNetSerializer()
         {
+            this.serializer = new JsonSerializer();
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="JsonNetSerializer"/> class,
-        /// with the provided <paramref name="converters"/>.
+        /// with the provided <paramref name="serializer"/>.
         /// </summary>
-        /// <param name="converters">Json converters used when serializing.</param>
-        public JsonNetSerializer(IEnumerable<JsonConverter> converters)
+        /// <param name="serializer">Json converters used when serializing.</param>
+        public JsonNetSerializer(JsonSerializer serializer)
         {
-            foreach (var converter in converters)
-            {
-                this.serializer.Converters.Add(converter);
-            }
+            this.serializer = serializer;
         }
 
         /// <summary>


### PR DESCRIPTION
Additional constructor for BodyDeserializer and Serializer now takes a JSonSerializer for full customization. Removed the need for converters in constructors.

Converters are now passed in to the JsonSerializer used in the constructor.
