### PR TITLE
Reset the bodyStream position before reading

### DIFF
--- a/src/Nancy.Serialization.JsonNet/JsonNetBodyDeserializer.cs
+++ b/src/Nancy.Serialization.JsonNet/JsonNetBodyDeserializer.cs
@@ -51,6 +51,8 @@
         /// <returns>Model instance</returns>
         public object Deserialize(MediaRange mediaRange, Stream bodyStream, BindingContext context)
         {
+            bodyStream.Position = 0;
+
             var deserializedObject =
                 this.serializer.Deserialize(new StreamReader(bodyStream), context.DestinationType);
 

--- a/src/Nancy.Serialization.JsonNet/JsonNetBodyDeserializer.cs
+++ b/src/Nancy.Serialization.JsonNet/JsonNetBodyDeserializer.cs
@@ -51,7 +51,10 @@
         /// <returns>Model instance</returns>
         public object Deserialize(MediaRange mediaRange, Stream bodyStream, BindingContext context)
         {
-            bodyStream.Position = 0;
+            if (bodyStream.CanSeek)
+            {
+                bodyStream.Position = 0;
+            }
 
             var deserializedObject =
                 this.serializer.Deserialize(new StreamReader(bodyStream), context.DestinationType);


### PR DESCRIPTION
This reproduce what the BodyDeserializers included with Nancy already do
and solve the problem when using Bind<> twice.

Fixes #22