### PR TITLE
Updated JsonNetBodyDeserializer.cs to support array types

### DIFF
--- a/test/Nancy.Serialization.JsonNet.Tests/JsonNetBodyDeserializerFixture.cs
+++ b/test/Nancy.Serialization.JsonNet.Tests/JsonNetBodyDeserializerFixture.cs
@@ -89,5 +89,96 @@
             Assert.Equal("some string value", actualData.SomeString);
             Assert.Equal(guid, actualData.SomeGuid);
         }
+
+        [Fact]
+        public void when_deserializing_directly_to_array_of_string()
+        {
+            // Given
+            string source = "['first', 'second', 'third']";
+
+            var context = new BindingContext
+            {
+                DestinationType = typeof(string[]),
+                ValidModelBindingMembers = new BindingMemberInfo[0],
+            };
+
+            // When
+            object actual;
+            using (var bodyStream = new MemoryStream(Encoding.UTF8.GetBytes(source)))
+            {
+                IBodyDeserializer sut = new JsonNetBodyDeserializer();
+                actual = sut.Deserialize("application/json", bodyStream, context);
+            }
+
+            // Then
+            var actualData = Assert.IsType<string[]>(actual);
+            Assert.Equal(3, actualData.Length);
+            Assert.Equal("first", actualData[0]);
+            Assert.Equal("second", actualData[1]);
+            Assert.Equal("third", actualData[2]);
+        }
+
+        [Fact]
+        public void when_deserializing_directly_to_array_of_tuple()
+        {
+            // Given
+            string source = "[{'Item1': 'first', 'Item2': 'second'}, {'Item1': 'third', 'Item2': 'fourth'}]";
+
+            var context = new BindingContext
+            {
+                DestinationType = typeof(Tuple<string, string>[]),
+                ValidModelBindingMembers = typeof(Tuple<string, string>).GetProperties(BindingFlags.Public | BindingFlags.Instance).Select(p => new BindingMemberInfo(p)),
+            };
+
+            // When
+            object actual;
+            using (var bodyStream = new MemoryStream(Encoding.UTF8.GetBytes(source)))
+            {
+                IBodyDeserializer sut = new JsonNetBodyDeserializer();
+                actual = sut.Deserialize("application/json", bodyStream, context);
+            }
+
+            // Then
+            var actualData = Assert.IsType<Tuple<string, string>[]>(actual);
+            Assert.Equal(2, actualData.Length);
+            Assert.Equal("first", actualData[0].Item1);
+            Assert.Equal("second", actualData[0].Item2);
+            Assert.Equal("third", actualData[1].Item1);
+            Assert.Equal("fourth", actualData[1].Item2);
+        }
+
+        [Fact]
+        public void when_deserializing_directly_to_array_of_pod_type()
+        {
+            // Given
+            string source = "[{'someString': 'first', 'someGuid': '<GUID>'}, {'someString': 'second', 'someGuid': '<GUID>'}]";
+
+            source = System.Text.RegularExpressions.Regex.Replace(
+                source,
+                @"\<GUID\>",
+                (match) => Guid.NewGuid().ToString());
+
+            var context = new BindingContext
+            {
+                DestinationType = typeof(TestData[]),
+                ValidModelBindingMembers = typeof(TestData).GetProperties(BindingFlags.Public | BindingFlags.Instance).Select(p => new BindingMemberInfo(p)),
+            };
+
+            // When
+            object actual;
+            using (var bodyStream = new MemoryStream(Encoding.UTF8.GetBytes(source)))
+            {
+                IBodyDeserializer sut = new JsonNetBodyDeserializer();
+                actual = sut.Deserialize("application/json", bodyStream, context);
+            }
+
+            // Then
+            var actualData = Assert.IsType<TestData[]>(actual);
+            Assert.Equal(2, actualData.Length);
+            Assert.Equal("first", actualData[0].SomeString);
+            Assert.NotEqual(Guid.Empty, actualData[0].SomeGuid);
+            Assert.Equal("second", actualData[1].SomeString);
+            Assert.NotEqual(Guid.Empty, actualData[1].SomeGuid);
+        }
     }
 }


### PR DESCRIPTION
After encountering errors doing model binding to array types, I investigated the root cause and decided to fix it. It looks like JsonNetBodyDeserializer.cs creates a separate instance of the target type from that created during deserialization, and then manually copies properties over in order to support blacklisting of properties (a Nancy feature not directly integrated with Newtonsoft.Json). As part of this, JsonNetBodyDeserializer.cs assumes that it can use `Activator.CreateInstance` on the destination type. This does not work for arrays, as they do not have a parameterless constructor. The approach I took, since the deserialization is going to require the use of a `List<T>` anyway, is to leverage the existing `List<T>` deserialization, and then if the destination type is actually `T[]`, call `List<T>`'s `ToArray` method before returning the final value.

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy.Serialization.JsonNet/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [x] I have provided test coverage for my change (where applicable)

### Description
* To avoid performance issues that might be associated with using late binding to dynamically call `ToArray`, I generate dynamic method specializations to perform the call to `List<T>.ToArray`, and I set up a simple cache of delegates referring to these methods.
* If `CreateObjectWithBlacklistExcluded` detects an array type `T[]`, a new method `ConvertArray` is called which retrieves this converter from the cache (constructing it if necessary) and applies it to the result of `ConvertCollection` on `List<T>`.
* The order of operations in `CreateObjectWithBlacklistExcluded` is altered so that `Activator.CreateInstance` is not called on the destination type in this circumstance.
* Unit tests verify the new functionality with arrays of various element types.

<!-- Thanks for contributing to Nancy! -->
